### PR TITLE
Work

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,6 +19,11 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    //setters
+    public void setTitle(String newTitle){this.title = newTitle;}
+    public void setAuthor(String newAuthor){this.author = newAuthor;}
+    public void setId(UUID newId){this.id = newId;}
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +42,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+                //author.equals(theOtherBook.author) &&
+                //title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -19,6 +19,11 @@ public abstract class Movie implements StoreMediaOperations {
         this.id = anotherMovie.id;
     }
 
+    //setters
+    public void setTitle(String newTitle){this.title = newTitle;}
+    public void setRating(String newRating){this.rating = newRating;}
+    public void setId(UUID newId){this.id = newId;}
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +42,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+                //rating.equals(theOtherMovie.rating) &&
+                //title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -1,17 +1,31 @@
 import Problem3.*;
 import org.junit.Test;
 
+import javax.swing.border.TitledBorder;
+
 import static org.junit.Assert.*;
 
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
-        // quiz
+        BookFiction f = new BookFiction("t1", "au1", "g1"); //create new objects
+        BookFiction fc = new BookFiction(f);
+
+        fc.setTitle("t3");  //change variables (id should be the same)
+        fc.setAuthor("a3");
+
+        assert(f.equals(fc));   //should pass only if the id are the same
     }
 
     @Test
     public void catchTheBugInMovie() {
-        // quiz
+        MovieAction m = new MovieAction("PG13", "ti1"); //create new objects
+        MovieAction mc = new MovieAction(m);
+
+        mc.setTitle("t3");  //change variables (id should be the same)
+        mc.setRating("PG");
+
+        assert(m.equals(mc));   //should pass only if the id are the same
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -12,7 +12,7 @@ public class Problem3Test {
         BookFiction fc = new BookFiction(f);
 
         fc.setTitle("t3");  //change variables (id should be the same)
-        fc.setAuthor("a3");
+        fc.setAuthor("a3"); //forces the objects to not be the same except the id which we are looking for
 
         assert(f.equals(fc));   //should pass only if the id are the same
     }
@@ -23,7 +23,7 @@ public class Problem3Test {
         MovieAction mc = new MovieAction(m);
 
         mc.setTitle("t3");  //change variables (id should be the same)
-        mc.setRating("PG");
+        mc.setRating("PG"); //forces the objects to not be the same except the id which we are looking for
 
         assert(m.equals(mc));   //should pass only if the id are the same
     }


### PR DESCRIPTION
The bug is allowed to pass because the assert() needs a true statement to pass. The bug finds if the id, title, author/rating, or genres to check if the objects are the same. These are true because the first object was used for the second object in a copy constructor. Since I changed the variables within the objects but kept the id the same, the old code should fail and the opposite for the new code. Basically, the old code uses 3 statements in an "and" statement, 2 statements which we are not looking for, while the new code uses only one statement with the information we need. In the case of the new code, since we are only looking for the id's being the same, it shouldn't matter if all the variables change except the id, it should still pass.